### PR TITLE
Make ParseRun test mock compatible with metadata field

### DIFF
--- a/src/wrapper/resources/parseRuns/ParseRunsWrapper.test.ts
+++ b/src/wrapper/resources/parseRuns/ParseRunsWrapper.test.ts
@@ -43,8 +43,12 @@ function createMockParseRun(
     outputUrl: null,
     metrics: null,
     usage: null,
+    // `metadata` is intentionally omitted: it is a required field on the
+    // regenerated `ParseRun` type but does not exist on older generated
+    // types. The cast below keeps this mock compiling across both, since the
+    // wrapper polling logic under test never reads `metadata`.
     ...overrides,
-  };
+  } as Extend.ParseRun;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- The 2026-02-09 API spec adds a required, nullable `metadata` field to `ParseRun` (the production `parseRunToPublicParseRun_2026_02_09` transform always returns `metadata: parserRun.metadata ?? null`).
- `createMockParseRun` in the parse-runs wrapper test spreads `Partial<Extend.ParseRun>` overrides, which widened `metadata` to `RunMetadata | null | undefined`. Once `metadata` becomes a required field after SDK regeneration, that no longer satisfies `RunMetadata | null`, breaking the docs repo's integration-test generation (`fern generate --preview`).
- Cast the mock return to `Extend.ParseRun` so it compiles both against the currently-committed generated types (which don't yet have `metadata`) and the regenerated types (which require it). The polling logic under test never reads `metadata`.

## Context
This unblocks the docs PR that introduces the field: extend-hq/documentation#395.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx jest .../ParseRunsWrapper.test.ts` — 5/5 pass