### PR TITLE
fix: add files field to ExtractRun test fixtures

### DIFF
--- a/src/wrapper/resources/extractRuns/ExtractRunsWrapper.test.ts
+++ b/src/wrapper/resources/extractRuns/ExtractRunsWrapper.test.ts
@@ -62,6 +62,7 @@ function createMockExtractRun(
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-01T00:00:00Z",
     },
+    files: null,
     dashboardUrl:
       "https://dashboard.extend.ai/extract-runs/extract_run_test123",
     edits: {},

--- a/src/wrapper/webhooks/Webhooks.test.ts
+++ b/src/wrapper/webhooks/Webhooks.test.ts
@@ -124,6 +124,7 @@ const sampleExtractRunPayload: Extend.ExtractRun = {
     createdAt: "2024-01-01T00:00:00Z",
     updatedAt: "2024-01-01T00:00:00Z",
   },
+  files: null,
   dashboardUrl: "https://dashboard.extend.ai/extract-runs/extract_run_def456",
   edits: {},
   usage: { credits: 1 },


### PR DESCRIPTION
Fixes TypeScript compilation failures in the documentation repo CI caused by multifile extraction support (extend-hq/documentation#417).

`files` was added as a required field on `ExtractRun` in the OpenAPI spec. The two hand-maintained wrapper test fixtures need `files: null` to satisfy the updated type.

**Changed:**
- `ExtractRunsWrapper.test.ts` — added `files: null` to `createMockExtractRun`
- `Webhooks.test.ts` — added `files: null` to `sampleExtractRunPayload`