### PR TITLE
add createdBy to wrapper test fixtures

### DIFF
--- a/src/wrapper/resources/classifyRuns/ClassifyRunsWrapper.test.ts
+++ b/src/wrapper/resources/classifyRuns/ClassifyRunsWrapper.test.ts
@@ -42,6 +42,7 @@ function createMockClassifyRun(
       classifierId: "classifier_123",
       description: null,
       createdAt: "2024-01-01T00:00:00Z",
+      createdBy: null,
     },
     status: "PROCESSED",
     output: { id: "class_1", type: "invoice", confidence: 0.95, insights: [] },

--- a/src/wrapper/resources/extractRuns/ExtractRunsWrapper.test.ts
+++ b/src/wrapper/resources/extractRuns/ExtractRunsWrapper.test.ts
@@ -43,6 +43,7 @@ function createMockExtractRun(
       extractorId: "extractor_123",
       description: null,
       createdAt: "2024-01-01T00:00:00Z",
+      createdBy: null,
     },
     status: "PROCESSED",
     output: { value: {}, metadata: {} },

--- a/src/wrapper/resources/splitRuns/SplitRunsWrapper.test.ts
+++ b/src/wrapper/resources/splitRuns/SplitRunsWrapper.test.ts
@@ -39,6 +39,7 @@ function createMockSplitRun(
       splitterId: "splitter_123",
       description: null,
       createdAt: "2024-01-01T00:00:00Z",
+      createdBy: null,
     },
     status: "PROCESSED",
     output: { splits: [] },

--- a/src/wrapper/resources/workflowRuns/WorkflowRunsWrapper.test.ts
+++ b/src/wrapper/resources/workflowRuns/WorkflowRunsWrapper.test.ts
@@ -34,6 +34,7 @@ function createMockWorkflowRun(
       name: "Test Workflow",
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-01T00:00:00Z",
+      createdBy: null,
     },
     workflowVersion: {
       object: "workflow_version",
@@ -41,6 +42,7 @@ function createMockWorkflowRun(
       version: "1",
       name: "Test Workflow v1",
       createdAt: "2024-01-01T00:00:00Z",
+      createdBy: null,
     },
     status: "PROCESSED",
     dashboardUrl:

--- a/src/wrapper/webhooks/Webhooks.test.ts
+++ b/src/wrapper/webhooks/Webhooks.test.ts
@@ -45,6 +45,7 @@ const sampleWorkflowRunPayload: Extend.WorkflowRun = {
     name: "Test Workflow",
     createdAt: "2024-01-01T00:00:00Z",
     updatedAt: "2024-01-01T00:00:00Z",
+    createdBy: null,
   },
   workflowVersion: {
     object: "workflow_version",
@@ -52,6 +53,7 @@ const sampleWorkflowRunPayload: Extend.WorkflowRun = {
     version: "1",
     name: "Test Workflow v1",
     createdAt: "2024-01-01T00:00:00Z",
+    createdBy: null,
   },
   dashboardUrl: "https://dashboard.extend.ai/workflows/workflow_run_abc123",
   status: "PROCESSED",
@@ -105,6 +107,7 @@ const sampleExtractRunPayload: Extend.ExtractRun = {
     extractorId: "extractor_123",
     description: null,
     createdAt: "2024-01-01T00:00:00Z",
+    createdBy: null,
   },
   status: "PROCESSED",
   output: { value: { field: "value" }, metadata: {} },


### PR DESCRIPTION
Adds ``createdBy: null`` to wrapper test fixtures that construct ``WorkflowSummary``, ``WorkflowVersionSummary``, ``ExtractorVersionSummary``, ``ClassifierVersionSummary``, and ``SplitterVersionSummary``. The API spec added ``createdBy`` as a required field on these types (nullable — ``null`` for resources created before attribution was tracked, populated otherwise), so the fixtures now need it to satisfy the type.

Affected fixtures:
- ``src/wrapper/resources/classifyRuns/ClassifyRunsWrapper.test.ts`` — ``classifierVersion``
- ``src/wrapper/resources/extractRuns/ExtractRunsWrapper.test.ts`` — ``extractorVersion``
- ``src/wrapper/resources/splitRuns/SplitRunsWrapper.test.ts`` — ``splitterVersion``
- ``src/wrapper/resources/workflowRuns/WorkflowRunsWrapper.test.ts`` — ``workflow``, ``workflowVersion``
- ``src/wrapper/webhooks/Webhooks.test.ts`` — ``workflow``, ``workflowVersion``, ``extractorVersion``